### PR TITLE
Use latest npm version in release workflow npm publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm run pkg:all
+      - run: npm install -g npm@latest  # trusted publishing requires later version of npm then in node 22 but we need node 22 for tree-sitter right now
       - run: npm publish --provenance --access public
 
       - name: Upload Linux binary


### PR DESCRIPTION
Added command to update npm to the latest version for trusted publishing.  Rest of release workflow, build, testing and packaging are using npm version aligned with node 22 which is required for tree-sitter compatibility.